### PR TITLE
Change date to datetime in SQL table schema

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -35,10 +35,10 @@ CREATE TABLE Botanist (
 CREATE TABLE Record (
     id BIGINT PRIMARY KEY,
     plant_id SMALLINT,
-    recording_taken DATE,
+    recording_taken DATETIME,
     moisture FLOAT,
     temperature FLOAT,
-    last_watered DATE,
+    last_watered DATETIME,
     botanist_id SMALLINT,
     FOREIGN KEY (plant_id) REFERENCES Plant(plant_id),
     FOREIGN KEY (botanist_id) REFERENCES Botanist(botanist_id)


### PR DESCRIPTION
This pull request updates the `Record` table schema to improve the precision of date and time tracking for plant care activities. The most important change is replacing the `DATE` type with `DATETIME` for certain columns to allow storing both the date and the time of events.

Database schema improvements:

* Changed the `recording_taken` column in the `Record` table from `DATE` to `DATETIME` to store both date and time of the recording.
* Changed the `last_watered` column in the `Record` table from `DATE` to `DATETIME` to store both date and time of the last watering event.

 Closes #41 