### PR TITLE
add terraform code for resources glue and athena resources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,7 +62,7 @@ resource "aws_lambda_function" "plant_load" {
   function_name = "c21-boxen-plant-load-pipeline"
   role          = aws_iam_role.lambda_role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.lambda_repo.repository_url}:latest"
+  image_uri     = "${aws_ecr_repository.lambda_repo.repository_url}:v4"
   timeout       = 300
   memory_size   = 512
 


### PR DESCRIPTION
This pull request will merge terraform code that creates:
A glue crawler : c21-boxen-plants-db
A glue catalogue database : c21-boxen-plants-crawler
As well as a glue crawler role, with glue service policy and custom s3 read/write permissions policy
A workgroup for Athena queries: c21-boxen-plants-workgroup