### PR TITLE
add new policy for eventbridge to execute lambda

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -273,6 +273,15 @@ resource "aws_iam_role_policy" "archive_scheduler_lambda_policy" {
   })
 }
 
+# Permission for EventBridge Scheduler to invoke Archive Lambda
+resource "aws_lambda_permission" "allow_eventbridge_archive" {
+  statement_id  = "AllowExecutionFromEventBridgeScheduler"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.archive_pipeline.function_name
+  principal     = "scheduler.amazonaws.com"
+  source_arn    = aws_scheduler_schedule.archive_schedule.arn
+}
+
 # S3 bucket for daily plant summaries
 resource "aws_s3_bucket" "plant_archive" {
   bucket = "c21-boxen-botanical-archive"


### PR DESCRIPTION
## Summary

Added missing Lambda resource policy allowing EventBridge Scheduler to invoke the archive pipeline Lambda function.

## Issue
The archive schedule was created and enabled but never executed automatically at 11:59 PM as expected. Investigation revealed the Lambda was missing the required permission for EventBridge Scheduler to invoke it.

## Changes

- Added aws_lambda_permission.allow_eventbridge_archive resource
- Grants scheduler.amazonaws.com permission to invoke c21-boxen-archive-pipeline
- Restricts permission to only the specific schedule ARN for security

## Testing

- [x] Verified Lambda resource policy contains scheduler permission

 

- [ ] Confirmed automatic execution at 11:59 PM UTC (pending tonight's run)